### PR TITLE
Break on 401 as well

### DIFF
--- a/src/ExponentialBackoff.php
+++ b/src/ExponentialBackoff.php
@@ -61,7 +61,7 @@ class ExponentialBackoff
                     }
                 }
 
-                if ($exception->getCode() == 403) {
+                if ($exception->getCode() == 401 || $exception->getCode() == 403) {
                     break;
                 }
 


### PR DESCRIPTION
Hello @schulzefelix 

thanks for providing this neat library. I'm just working on a project using it and stumbled upon a long delay with a request. While researching the problem I found out that my token was invalid:

![error_2](https://user-images.githubusercontent.com/8433587/81396125-dfaa5e00-9135-11ea-8ca1-3f6c49a00189.png)

The break in the `ExponentialBackoff`-class didn't catch it due to the error code being 401 instead of 403. I've fixed this with this PR. Maybe something you would like to consider.

Viele Grüße nach Berlin!
Peter


