### PR TITLE
Added use for Str and modified check for a rows keys prop

### DIFF
--- a/src/SearchConsoleClient.php
+++ b/src/SearchConsoleClient.php
@@ -7,6 +7,7 @@ use Google_Service_Webmasters;
 use GuzzleHttp\Client;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 class SearchConsoleClient
 {
@@ -67,7 +68,7 @@ class SearchConsoleClient
                  * https://productforums.google.com/forum/?hl=en#!topic/webmasters/wF_Rm9CGr4U
                  */
 
-                if (count($row->getKeys())) {
+                if (is_array($row->getKeys()) && count($row->getKeys())) {
                     $item = array_combine($request->getDimensions(), $row->getKeys());
                     $uniqueHash = $this->getUniqueItemHash($row, $request);
                 } else {


### PR DESCRIPTION
When passing no dimensions in order to retrieve an [overview](https://support.google.com/webmasters/thread/20718543?hl=en), the keys property is empty, calling count() on $row->getKeys() to fail.

I added a check to make sure it's an array, which forces the else.

I then added a use statement for Str, as it wasn't included in the class.