### PR TITLE
allow to set datastate in order to retrieve fresh data

### DIFF
--- a/src/SearchConsole.php
+++ b/src/SearchConsole.php
@@ -97,13 +97,14 @@ class SearchConsole
      * @return Collection
      * @throws \Exception
      */
-    public function searchAnalyticsQuery(string $siteUrl, Period $period, array $dimensions = [], array $filters = [], int $rows = 1000, string $searchType = 'web')
+    public function searchAnalyticsQuery(string $siteUrl, Period $period, array $dimensions = [], array $filters = [], int $rows = 1000, string $searchType = 'web', string $dataState = null)
     {
         $request = new Google_Service_Webmasters_SearchAnalyticsQueryRequest();
         $request->setStartDate($period->startDate->toDateString());
         $request->setEndDate($period->endDate->toDateString());
         $request->setSearchType($searchType);
         $request->setDimensions($dimensions);
+        $request->setDataState($dataState);
         $request = $this->applyFilters($request, $filters);
 
         return $this->client->performQuery($siteUrl, $rows, $request);


### PR DESCRIPTION
As described here https://searchengineland.com/google-search-console-api-gains-fresh-data-more-344552, by setting the datastate to `all` it is possible to retrieve fresh data (less than 1 day old).

The default is null which is the current behaviour